### PR TITLE
test: Add e2e tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ lint:
 
 .PHONY: e2e-tests
 e2e-tests: annotated-policy.wasm
-	@echo "Dummy target to allow using the reusable github actions to build, test and release policies"
+	bats e2e.bats
 
 .PHONY: test
 test: fmt lint

--- a/e2e.bats
+++ b/e2e.bats
@@ -1,0 +1,50 @@
+@test "Accept all capabilities when star in allowed capabilities" {
+  run kwctl run  --request-path test_data/req_pod_with_allowed_capabilities_accept.json --settings-json '{"allowed_capabilities": ["*"]}' annotated-policy.wasm
+  [ "$status" -eq 0 ]
+  echo "$output"
+  [ $(expr "$output" : '.*"allowed":true.*') -ne 0 ]
+  run kwctl run  --request-path test_data/req_pod_with_allowed_capabilities_reject.json --settings-json '{"allowed_capabilities": ["*"]}' annotated-policy.wasm
+  echo "$output"
+  [ $(expr "$output" : '.*"allowed":true.*') -ne 0 ]
+}
+
+@test "Reject when star in allowed capabilities and capabilities in required_drop_capabilities" {
+  run kwctl run  --request-path test_data/req_pod_with_allowed_capabilities_reject.json --settings-json '{"allowed_capabilities": ["*"], "required_drop_capabilities": ["BPF"]}' annotated-policy.wasm
+  [ "$status" -eq 0 ]
+  echo "$output"
+  [ $(expr "$output" : '.*"allowed":false.*') -ne 0 ]
+  [ $(expr "$output" : '.*"message":"PSP capabilities policies doesn'\''t allow these capabilities to be added*') -ne 0 ]
+ 
+}
+@test "Reject capabilities in required_drop_capabilities" {
+  run kwctl run  --request-path test_data/req_pod_with_capabilities_in_required_drop_capabilities.json --settings-json '{"required_drop_capabilities": ["NET_ADMIN"]}' annotated-policy.wasm
+  [ "$status" -eq 0 ]
+  echo "$output"
+  [ $(expr "$output" : '.*"allowed":false.*') -ne 0 ]
+  [ $(expr "$output" : '.*"message":"PSP capabilities policies doesn'\''t allow these capabilities to be added*') -ne 0 ]
+}
+
+
+@test "Accept capabilities in allowed capabilities" {
+  run kwctl run  --request-path test_data/req_pod_with_allowed_capabilities_accept.json --settings-json '{"allowed_capabilities": ["CHOWN", "KILL"]}' annotated-policy.wasm
+  [ "$status" -eq 0 ]
+  echo "$output"
+  [ $(expr "$output" : '.*"allowed":true.*') -ne 0 ]
+}
+
+@test "Reject capabilities not in allowed capabilities" {
+  run kwctl run  --request-path test_data/req_pod_with_allowed_capabilities_reject.json --settings-json '{"allowed_capabilities": ["CHOWN", "KILL"]}' annotated-policy.wasm
+  [ "$status" -eq 0 ]
+  echo "$output"
+  [ $(expr "$output" : '.*"allowed":false.*') -ne 0 ]
+  [ $(expr "$output" : '.*"message":"PSP capabilities policies doesn'\''t allow these capabilities to be added*') -ne 0 ]
+}
+
+
+
+@test "Mutate pods" {
+  run kwctl run  --request-path test_data/req_pod_with_mutate_capabilities.json --settings-json '{"allowed_capabilities": ["CHOWN", "KILL"], "required_drop_capabilities":["NET_ADMIN"], "default_add_capabilities":["CHOWN"]}' annotated-policy.wasm
+  echo "$output"
+  [ $(expr "$output" : '.*"allowed":true.*') -ne 0 ]
+  [ $(expr "$output" : '.*"patchType":"JSONPatch"') -ne 0 ]
+}

--- a/src/validate.rs
+++ b/src/validate.rs
@@ -36,7 +36,7 @@ pub(crate) fn validate_added_caps(validation_req: &ValidationRequest<Settings>) 
 
     if !must_be_dropped.is_empty() {
         return Err(anyhow!(
-            "PSP capabilities policies doesn't allow these capabilities to be added because they are no the `required_drop_capabilities` list: {:?}",
+            "PSP capabilities policies doesn't allow these capabilities to be added because they are on the `required_drop_capabilities` list: {:?}",
             must_be_dropped
         ));
     }

--- a/test_data/req_pod_with_allowed_capabilities_accept.json
+++ b/test_data/req_pod_with_allowed_capabilities_accept.json
@@ -1,0 +1,198 @@
+{
+  "dryRun": false,
+  "kind": {
+      "group": "",
+      "kind": "Pod",
+      "version": "v1"
+  },
+  "name": "hello",
+  "namespace": "default",
+  "object": {
+      "apiVersion": "v1",
+      "kind": "Pod",
+      "metadata": {
+          "annotations": {
+              "io.kubewarden.policy.echo.create": "true",
+              "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Pod\",\"metadata\":{\"annotations\":{\"io.kubewarden.policy.echo.create\":\"true\"},\"name\":\"hello\",\"namespace\":\"default\"},\"spec\":{\"containers\":[{\"command\":[\"sh\",\"-c\",\"echo 'Hello!' \\u0026\\u0026 sleep 1h\"],\"image\":\"busybox\",\"name\":\"hello\",\"securityContext\":{\"capabilities\":{\"add\":[\"NET_ADMIN\"]}}}]}}\n"
+          },
+          "creationTimestamp": "2023-04-12T12:42:27Z",
+          "managedFields": [
+              {
+                  "apiVersion": "v1",
+                  "fieldsType": "FieldsV1",
+                  "fieldsV1": {
+                      "f:metadata": {
+                          "f:annotations": {
+                              ".": {},
+                              "f:io.kubewarden.policy.echo.create": {},
+                              "f:kubectl.kubernetes.io/last-applied-configuration": {}
+                          }
+                      },
+                      "f:spec": {
+                          "f:containers": {
+                              "k:{\"name\":\"hello\"}": {
+                                  ".": {},
+                                  "f:command": {},
+                                  "f:image": {},
+                                  "f:imagePullPolicy": {},
+                                  "f:name": {},
+                                  "f:resources": {},
+                                  "f:securityContext": {
+                                      ".": {},
+                                      "f:capabilities": {
+                                          ".": {},
+                                          "f:add": {}
+                                      }
+                                  },
+                                  "f:terminationMessagePath": {},
+                                  "f:terminationMessagePolicy": {}
+                              }
+                          },
+                          "f:dnsPolicy": {},
+                          "f:enableServiceLinks": {},
+                          "f:restartPolicy": {},
+                          "f:schedulerName": {},
+                          "f:securityContext": {},
+                          "f:terminationGracePeriodSeconds": {}
+                      }
+                  },
+                  "manager": "kubectl-client-side-apply",
+                  "operation": "Update",
+                  "time": "2023-04-12T12:42:27Z"
+              }
+          ],
+          "name": "hello",
+          "namespace": "default",
+          "uid": "d1dbc79a-8b52-4396-a882-a3fb8549a546"
+      },
+      "spec": {
+          "containers": [
+              {
+                  "command": [
+                      "sh",
+                      "-c",
+                      "echo 'Hello!' && sleep 1h"
+                  ],
+                  "image": "busybox",
+                  "imagePullPolicy": "Always",
+                  "name": "hello",
+                  "resources": {},
+                  "securityContext": {
+                      "capabilities": {
+                          "add": [
+                              "CHOWN"
+                          ]
+                      }
+                  },
+                  "terminationMessagePath": "/dev/termination-log",
+                  "terminationMessagePolicy": "File",
+                  "volumeMounts": [
+                      {
+                          "mountPath": "/var/run/secrets/kubernetes.io/serviceaccount",
+                          "name": "kube-api-access-g4mxk",
+                          "readOnly": true
+                      }
+                  ]
+              }
+          ],
+          "dnsPolicy": "ClusterFirst",
+          "enableServiceLinks": true,
+          "preemptionPolicy": "PreemptLowerPriority",
+          "priority": 0,
+          "restartPolicy": "Always",
+          "schedulerName": "default-scheduler",
+          "securityContext": {},
+          "serviceAccount": "default",
+          "serviceAccountName": "default",
+          "terminationGracePeriodSeconds": 30,
+          "tolerations": [
+              {
+                  "effect": "NoExecute",
+                  "key": "node.kubernetes.io/not-ready",
+                  "operator": "Exists",
+                  "tolerationSeconds": 300
+              },
+              {
+                  "effect": "NoExecute",
+                  "key": "node.kubernetes.io/unreachable",
+                  "operator": "Exists",
+                  "tolerationSeconds": 300
+              }
+          ],
+          "volumes": [
+              {
+                  "name": "kube-api-access-g4mxk",
+                  "projected": {
+                      "defaultMode": 420,
+                      "sources": [
+                          {
+                              "serviceAccountToken": {
+                                  "expirationSeconds": 3607,
+                                  "path": "token"
+                              }
+                          },
+                          {
+                              "configMap": {
+                                  "items": [
+                                      {
+                                          "key": "ca.crt",
+                                          "path": "ca.crt"
+                                      }
+                                  ],
+                                  "name": "kube-root-ca.crt"
+                              }
+                          },
+                          {
+                              "downwardAPI": {
+                                  "items": [
+                                      {
+                                          "fieldRef": {
+                                              "apiVersion": "v1",
+                                              "fieldPath": "metadata.namespace"
+                                          },
+                                          "path": "namespace"
+                                      }
+                                  ]
+                              }
+                          }
+                      ]
+                  }
+              }
+          ]
+      },
+      "status": {
+          "phase": "Pending",
+          "qosClass": "BestEffort"
+      }
+  },
+  "operation": "CREATE",
+  "options": {
+      "apiVersion": "meta.k8s.io/v1",
+      "fieldManager": "kubectl-client-side-apply",
+      "fieldValidation": "Strict",
+      "kind": "CreateOptions"
+  },
+  "requestKind": {
+      "group": "",
+      "kind": "Pod",
+      "version": "v1"
+  },
+  "requestResource": {
+      "group": "",
+      "resource": "pods",
+      "version": "v1"
+  },
+  "resource": {
+      "group": "",
+      "resource": "pods",
+      "version": "v1"
+  },
+  "uid": "f0b8fba3-4f4f-465b-af8c-84d0326a2dc2",
+  "userInfo": {
+      "groups": [
+          "system:masters",
+          "system:authenticated"
+      ],
+      "username": "docker-for-desktop"
+  }
+}

--- a/test_data/req_pod_with_allowed_capabilities_accept.json
+++ b/test_data/req_pod_with_allowed_capabilities_accept.json
@@ -1,69 +1,12 @@
 {
-  "dryRun": false,
+  "uid": "f0b8fba3-4f4f-465b-af8c-84d0326a2dc2",
   "kind": {
-      "group": "",
       "kind": "Pod",
       "version": "v1"
   },
-  "name": "hello",
-  "namespace": "default",
   "object": {
-      "apiVersion": "v1",
-      "kind": "Pod",
       "metadata": {
-          "annotations": {
-              "io.kubewarden.policy.echo.create": "true",
-              "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Pod\",\"metadata\":{\"annotations\":{\"io.kubewarden.policy.echo.create\":\"true\"},\"name\":\"hello\",\"namespace\":\"default\"},\"spec\":{\"containers\":[{\"command\":[\"sh\",\"-c\",\"echo 'Hello!' \\u0026\\u0026 sleep 1h\"],\"image\":\"busybox\",\"name\":\"hello\",\"securityContext\":{\"capabilities\":{\"add\":[\"NET_ADMIN\"]}}}]}}\n"
-          },
-          "creationTimestamp": "2023-04-12T12:42:27Z",
-          "managedFields": [
-              {
-                  "apiVersion": "v1",
-                  "fieldsType": "FieldsV1",
-                  "fieldsV1": {
-                      "f:metadata": {
-                          "f:annotations": {
-                              ".": {},
-                              "f:io.kubewarden.policy.echo.create": {},
-                              "f:kubectl.kubernetes.io/last-applied-configuration": {}
-                          }
-                      },
-                      "f:spec": {
-                          "f:containers": {
-                              "k:{\"name\":\"hello\"}": {
-                                  ".": {},
-                                  "f:command": {},
-                                  "f:image": {},
-                                  "f:imagePullPolicy": {},
-                                  "f:name": {},
-                                  "f:resources": {},
-                                  "f:securityContext": {
-                                      ".": {},
-                                      "f:capabilities": {
-                                          ".": {},
-                                          "f:add": {}
-                                      }
-                                  },
-                                  "f:terminationMessagePath": {},
-                                  "f:terminationMessagePolicy": {}
-                              }
-                          },
-                          "f:dnsPolicy": {},
-                          "f:enableServiceLinks": {},
-                          "f:restartPolicy": {},
-                          "f:schedulerName": {},
-                          "f:securityContext": {},
-                          "f:terminationGracePeriodSeconds": {}
-                      }
-                  },
-                  "manager": "kubectl-client-side-apply",
-                  "operation": "Update",
-                  "time": "2023-04-12T12:42:27Z"
-              }
-          ],
-          "name": "hello",
-          "namespace": "default",
-          "uid": "d1dbc79a-8b52-4396-a882-a3fb8549a546"
+          "name": "hello"
       },
       "spec": {
           "containers": [
@@ -83,116 +26,22 @@
                               "CHOWN"
                           ]
                       }
-                  },
-                  "terminationMessagePath": "/dev/termination-log",
-                  "terminationMessagePolicy": "File",
-                  "volumeMounts": [
-                      {
-                          "mountPath": "/var/run/secrets/kubernetes.io/serviceaccount",
-                          "name": "kube-api-access-g4mxk",
-                          "readOnly": true
-                      }
-                  ]
-              }
-          ],
-          "dnsPolicy": "ClusterFirst",
-          "enableServiceLinks": true,
-          "preemptionPolicy": "PreemptLowerPriority",
-          "priority": 0,
-          "restartPolicy": "Always",
-          "schedulerName": "default-scheduler",
-          "securityContext": {},
-          "serviceAccount": "default",
-          "serviceAccountName": "default",
-          "terminationGracePeriodSeconds": 30,
-          "tolerations": [
-              {
-                  "effect": "NoExecute",
-                  "key": "node.kubernetes.io/not-ready",
-                  "operator": "Exists",
-                  "tolerationSeconds": 300
-              },
-              {
-                  "effect": "NoExecute",
-                  "key": "node.kubernetes.io/unreachable",
-                  "operator": "Exists",
-                  "tolerationSeconds": 300
-              }
-          ],
-          "volumes": [
-              {
-                  "name": "kube-api-access-g4mxk",
-                  "projected": {
-                      "defaultMode": 420,
-                      "sources": [
-                          {
-                              "serviceAccountToken": {
-                                  "expirationSeconds": 3607,
-                                  "path": "token"
-                              }
-                          },
-                          {
-                              "configMap": {
-                                  "items": [
-                                      {
-                                          "key": "ca.crt",
-                                          "path": "ca.crt"
-                                      }
-                                  ],
-                                  "name": "kube-root-ca.crt"
-                              }
-                          },
-                          {
-                              "downwardAPI": {
-                                  "items": [
-                                      {
-                                          "fieldRef": {
-                                              "apiVersion": "v1",
-                                              "fieldPath": "metadata.namespace"
-                                          },
-                                          "path": "namespace"
-                                      }
-                                  ]
-                              }
-                          }
-                      ]
                   }
+                  
               }
-          ]
-      },
-      "status": {
-          "phase": "Pending",
-          "qosClass": "BestEffort"
+          ]  
       }
   },
   "operation": "CREATE",
-  "options": {
-      "apiVersion": "meta.k8s.io/v1",
-      "fieldManager": "kubectl-client-side-apply",
-      "fieldValidation": "Strict",
-      "kind": "CreateOptions"
-  },
   "requestKind": {
-      "group": "",
       "kind": "Pod",
       "version": "v1"
   },
-  "requestResource": {
-      "group": "",
-      "resource": "pods",
-      "version": "v1"
-  },
-  "resource": {
-      "group": "",
-      "resource": "pods",
-      "version": "v1"
-  },
-  "uid": "f0b8fba3-4f4f-465b-af8c-84d0326a2dc2",
   "userInfo": {
       "groups": [
           "system:masters",
           "system:authenticated"
       ],
-      "username": "docker-for-desktop"
+      "username": "shiva"
   }
 }

--- a/test_data/req_pod_with_allowed_capabilities_reject.json
+++ b/test_data/req_pod_with_allowed_capabilities_reject.json
@@ -1,0 +1,198 @@
+{
+  "dryRun": false,
+  "kind": {
+      "group": "",
+      "kind": "Pod",
+      "version": "v1"
+  },
+  "name": "hello",
+  "namespace": "default",
+  "object": {
+      "apiVersion": "v1",
+      "kind": "Pod",
+      "metadata": {
+          "annotations": {
+              "io.kubewarden.policy.echo.create": "true",
+              "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Pod\",\"metadata\":{\"annotations\":{\"io.kubewarden.policy.echo.create\":\"true\"},\"name\":\"hello\",\"namespace\":\"default\"},\"spec\":{\"containers\":[{\"command\":[\"sh\",\"-c\",\"echo 'Hello!' \\u0026\\u0026 sleep 1h\"],\"image\":\"busybox\",\"name\":\"hello\",\"securityContext\":{\"capabilities\":{\"add\":[\"NET_ADMIN\"]}}}]}}\n"
+          },
+          "creationTimestamp": "2023-04-12T12:42:27Z",
+          "managedFields": [
+              {
+                  "apiVersion": "v1",
+                  "fieldsType": "FieldsV1",
+                  "fieldsV1": {
+                      "f:metadata": {
+                          "f:annotations": {
+                              ".": {},
+                              "f:io.kubewarden.policy.echo.create": {},
+                              "f:kubectl.kubernetes.io/last-applied-configuration": {}
+                          }
+                      },
+                      "f:spec": {
+                          "f:containers": {
+                              "k:{\"name\":\"hello\"}": {
+                                  ".": {},
+                                  "f:command": {},
+                                  "f:image": {},
+                                  "f:imagePullPolicy": {},
+                                  "f:name": {},
+                                  "f:resources": {},
+                                  "f:securityContext": {
+                                      ".": {},
+                                      "f:capabilities": {
+                                          ".": {},
+                                          "f:add": {}
+                                      }
+                                  },
+                                  "f:terminationMessagePath": {},
+                                  "f:terminationMessagePolicy": {}
+                              }
+                          },
+                          "f:dnsPolicy": {},
+                          "f:enableServiceLinks": {},
+                          "f:restartPolicy": {},
+                          "f:schedulerName": {},
+                          "f:securityContext": {},
+                          "f:terminationGracePeriodSeconds": {}
+                      }
+                  },
+                  "manager": "kubectl-client-side-apply",
+                  "operation": "Update",
+                  "time": "2023-04-12T12:42:27Z"
+              }
+          ],
+          "name": "hello",
+          "namespace": "default",
+          "uid": "d1dbc79a-8b52-4396-a882-a3fb8549a546"
+      },
+      "spec": {
+          "containers": [
+              {
+                  "command": [
+                      "sh",
+                      "-c",
+                      "echo 'Hello!' && sleep 1h"
+                  ],
+                  "image": "busybox",
+                  "imagePullPolicy": "Always",
+                  "name": "hello",
+                  "resources": {},
+                  "securityContext": {
+                      "capabilities": {
+                          "add": [
+                              "BPF"
+                          ]
+                      }
+                  },
+                  "terminationMessagePath": "/dev/termination-log",
+                  "terminationMessagePolicy": "File",
+                  "volumeMounts": [
+                      {
+                          "mountPath": "/var/run/secrets/kubernetes.io/serviceaccount",
+                          "name": "kube-api-access-g4mxk",
+                          "readOnly": true
+                      }
+                  ]
+              }
+          ],
+          "dnsPolicy": "ClusterFirst",
+          "enableServiceLinks": true,
+          "preemptionPolicy": "PreemptLowerPriority",
+          "priority": 0,
+          "restartPolicy": "Always",
+          "schedulerName": "default-scheduler",
+          "securityContext": {},
+          "serviceAccount": "default",
+          "serviceAccountName": "default",
+          "terminationGracePeriodSeconds": 30,
+          "tolerations": [
+              {
+                  "effect": "NoExecute",
+                  "key": "node.kubernetes.io/not-ready",
+                  "operator": "Exists",
+                  "tolerationSeconds": 300
+              },
+              {
+                  "effect": "NoExecute",
+                  "key": "node.kubernetes.io/unreachable",
+                  "operator": "Exists",
+                  "tolerationSeconds": 300
+              }
+          ],
+          "volumes": [
+              {
+                  "name": "kube-api-access-g4mxk",
+                  "projected": {
+                      "defaultMode": 420,
+                      "sources": [
+                          {
+                              "serviceAccountToken": {
+                                  "expirationSeconds": 3607,
+                                  "path": "token"
+                              }
+                          },
+                          {
+                              "configMap": {
+                                  "items": [
+                                      {
+                                          "key": "ca.crt",
+                                          "path": "ca.crt"
+                                      }
+                                  ],
+                                  "name": "kube-root-ca.crt"
+                              }
+                          },
+                          {
+                              "downwardAPI": {
+                                  "items": [
+                                      {
+                                          "fieldRef": {
+                                              "apiVersion": "v1",
+                                              "fieldPath": "metadata.namespace"
+                                          },
+                                          "path": "namespace"
+                                      }
+                                  ]
+                              }
+                          }
+                      ]
+                  }
+              }
+          ]
+      },
+      "status": {
+          "phase": "Pending",
+          "qosClass": "BestEffort"
+      }
+  },
+  "operation": "CREATE",
+  "options": {
+      "apiVersion": "meta.k8s.io/v1",
+      "fieldManager": "kubectl-client-side-apply",
+      "fieldValidation": "Strict",
+      "kind": "CreateOptions"
+  },
+  "requestKind": {
+      "group": "",
+      "kind": "Pod",
+      "version": "v1"
+  },
+  "requestResource": {
+      "group": "",
+      "resource": "pods",
+      "version": "v1"
+  },
+  "resource": {
+      "group": "",
+      "resource": "pods",
+      "version": "v1"
+  },
+  "uid": "f0b8fba3-4f4f-465b-af8c-84d0326a2dc2",
+  "userInfo": {
+      "groups": [
+          "system:masters",
+          "system:authenticated"
+      ],
+      "username": "docker-for-desktop"
+  }
+}

--- a/test_data/req_pod_with_allowed_capabilities_reject.json
+++ b/test_data/req_pod_with_allowed_capabilities_reject.json
@@ -1,198 +1,47 @@
 {
-  "dryRun": false,
-  "kind": {
-      "group": "",
-      "kind": "Pod",
-      "version": "v1"
-  },
-  "name": "hello",
-  "namespace": "default",
-  "object": {
-      "apiVersion": "v1",
-      "kind": "Pod",
-      "metadata": {
-          "annotations": {
-              "io.kubewarden.policy.echo.create": "true",
-              "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Pod\",\"metadata\":{\"annotations\":{\"io.kubewarden.policy.echo.create\":\"true\"},\"name\":\"hello\",\"namespace\":\"default\"},\"spec\":{\"containers\":[{\"command\":[\"sh\",\"-c\",\"echo 'Hello!' \\u0026\\u0026 sleep 1h\"],\"image\":\"busybox\",\"name\":\"hello\",\"securityContext\":{\"capabilities\":{\"add\":[\"NET_ADMIN\"]}}}]}}\n"
-          },
-          "creationTimestamp": "2023-04-12T12:42:27Z",
-          "managedFields": [
-              {
-                  "apiVersion": "v1",
-                  "fieldsType": "FieldsV1",
-                  "fieldsV1": {
-                      "f:metadata": {
-                          "f:annotations": {
-                              ".": {},
-                              "f:io.kubewarden.policy.echo.create": {},
-                              "f:kubectl.kubernetes.io/last-applied-configuration": {}
-                          }
-                      },
-                      "f:spec": {
-                          "f:containers": {
-                              "k:{\"name\":\"hello\"}": {
-                                  ".": {},
-                                  "f:command": {},
-                                  "f:image": {},
-                                  "f:imagePullPolicy": {},
-                                  "f:name": {},
-                                  "f:resources": {},
-                                  "f:securityContext": {
-                                      ".": {},
-                                      "f:capabilities": {
-                                          ".": {},
-                                          "f:add": {}
-                                      }
-                                  },
-                                  "f:terminationMessagePath": {},
-                                  "f:terminationMessagePolicy": {}
-                              }
-                          },
-                          "f:dnsPolicy": {},
-                          "f:enableServiceLinks": {},
-                          "f:restartPolicy": {},
-                          "f:schedulerName": {},
-                          "f:securityContext": {},
-                          "f:terminationGracePeriodSeconds": {}
-                      }
-                  },
-                  "manager": "kubectl-client-side-apply",
-                  "operation": "Update",
-                  "time": "2023-04-12T12:42:27Z"
-              }
-          ],
-          "name": "hello",
-          "namespace": "default",
-          "uid": "d1dbc79a-8b52-4396-a882-a3fb8549a546"
-      },
-      "spec": {
-          "containers": [
-              {
-                  "command": [
-                      "sh",
-                      "-c",
-                      "echo 'Hello!' && sleep 1h"
-                  ],
-                  "image": "busybox",
-                  "imagePullPolicy": "Always",
-                  "name": "hello",
-                  "resources": {},
-                  "securityContext": {
-                      "capabilities": {
-                          "add": [
-                              "BPF"
-                          ]
-                      }
-                  },
-                  "terminationMessagePath": "/dev/termination-log",
-                  "terminationMessagePolicy": "File",
-                  "volumeMounts": [
-                      {
-                          "mountPath": "/var/run/secrets/kubernetes.io/serviceaccount",
-                          "name": "kube-api-access-g4mxk",
-                          "readOnly": true
-                      }
-                  ]
-              }
-          ],
-          "dnsPolicy": "ClusterFirst",
-          "enableServiceLinks": true,
-          "preemptionPolicy": "PreemptLowerPriority",
-          "priority": 0,
-          "restartPolicy": "Always",
-          "schedulerName": "default-scheduler",
-          "securityContext": {},
-          "serviceAccount": "default",
-          "serviceAccountName": "default",
-          "terminationGracePeriodSeconds": 30,
-          "tolerations": [
-              {
-                  "effect": "NoExecute",
-                  "key": "node.kubernetes.io/not-ready",
-                  "operator": "Exists",
-                  "tolerationSeconds": 300
-              },
-              {
-                  "effect": "NoExecute",
-                  "key": "node.kubernetes.io/unreachable",
-                  "operator": "Exists",
-                  "tolerationSeconds": 300
-              }
-          ],
-          "volumes": [
-              {
-                  "name": "kube-api-access-g4mxk",
-                  "projected": {
-                      "defaultMode": 420,
-                      "sources": [
-                          {
-                              "serviceAccountToken": {
-                                  "expirationSeconds": 3607,
-                                  "path": "token"
-                              }
-                          },
-                          {
-                              "configMap": {
-                                  "items": [
-                                      {
-                                          "key": "ca.crt",
-                                          "path": "ca.crt"
-                                      }
-                                  ],
-                                  "name": "kube-root-ca.crt"
-                              }
-                          },
-                          {
-                              "downwardAPI": {
-                                  "items": [
-                                      {
-                                          "fieldRef": {
-                                              "apiVersion": "v1",
-                                              "fieldPath": "metadata.namespace"
-                                          },
-                                          "path": "namespace"
-                                      }
-                                  ]
-                              }
-                          }
-                      ]
-                  }
-              }
-          ]
-      },
-      "status": {
-          "phase": "Pending",
-          "qosClass": "BestEffort"
-      }
-  },
-  "operation": "CREATE",
-  "options": {
-      "apiVersion": "meta.k8s.io/v1",
-      "fieldManager": "kubectl-client-side-apply",
-      "fieldValidation": "Strict",
-      "kind": "CreateOptions"
-  },
-  "requestKind": {
-      "group": "",
-      "kind": "Pod",
-      "version": "v1"
-  },
-  "requestResource": {
-      "group": "",
-      "resource": "pods",
-      "version": "v1"
-  },
-  "resource": {
-      "group": "",
-      "resource": "pods",
-      "version": "v1"
-  },
-  "uid": "f0b8fba3-4f4f-465b-af8c-84d0326a2dc2",
-  "userInfo": {
-      "groups": [
-          "system:masters",
-          "system:authenticated"
-      ],
-      "username": "docker-for-desktop"
+    "uid": "f0b8fba3-4f4f-465b-af8c-84d0326a2dc2",
+    "kind": {
+        "kind": "Pod",
+        "version": "v1"
+    },
+    "object": {
+        "metadata": {
+            "name": "hello"
+        },
+        "spec": {
+            "containers": [
+                {
+                    "command": [
+                        "sh",
+                        "-c",
+                        "echo 'Hello!' && sleep 1h"
+                    ],
+                    "image": "busybox",
+                    "imagePullPolicy": "Always",
+                    "name": "hello",
+                    "resources": {},
+                    "securityContext": {
+                        "capabilities": {
+                            "add": [
+                                "BPF"
+                            ]
+                        }
+                    }
+                    
+                }
+            ]  
+        }
+    },
+    "operation": "CREATE",
+    "requestKind": {
+        "kind": "Pod",
+        "version": "v1"
+    },
+    "userInfo": {
+        "groups": [
+            "system:masters",
+            "system:authenticated"
+        ],
+        "username": "shiva"
+    }
   }
-}

--- a/test_data/req_pod_with_capabilities_in_required_drop_capabilities.json
+++ b/test_data/req_pod_with_capabilities_in_required_drop_capabilities.json
@@ -1,0 +1,198 @@
+{
+    "dryRun": false,
+    "kind": {
+        "group": "",
+        "kind": "Pod",
+        "version": "v1"
+    },
+    "name": "hello",
+    "namespace": "default",
+    "object": {
+        "apiVersion": "v1",
+        "kind": "Pod",
+        "metadata": {
+            "annotations": {
+                "io.kubewarden.policy.echo.create": "true",
+                "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Pod\",\"metadata\":{\"annotations\":{\"io.kubewarden.policy.echo.create\":\"true\"},\"name\":\"hello\",\"namespace\":\"default\"},\"spec\":{\"containers\":[{\"command\":[\"sh\",\"-c\",\"echo 'Hello!' \\u0026\\u0026 sleep 1h\"],\"image\":\"busybox\",\"name\":\"hello\",\"securityContext\":{\"capabilities\":{\"add\":[\"NET_ADMIN\"]}}}]}}\n"
+            },
+            "creationTimestamp": "2023-04-12T12:42:27Z",
+            "managedFields": [
+                {
+                    "apiVersion": "v1",
+                    "fieldsType": "FieldsV1",
+                    "fieldsV1": {
+                        "f:metadata": {
+                            "f:annotations": {
+                                ".": {},
+                                "f:io.kubewarden.policy.echo.create": {},
+                                "f:kubectl.kubernetes.io/last-applied-configuration": {}
+                            }
+                        },
+                        "f:spec": {
+                            "f:containers": {
+                                "k:{\"name\":\"hello\"}": {
+                                    ".": {},
+                                    "f:command": {},
+                                    "f:image": {},
+                                    "f:imagePullPolicy": {},
+                                    "f:name": {},
+                                    "f:resources": {},
+                                    "f:securityContext": {
+                                        ".": {},
+                                        "f:capabilities": {
+                                            ".": {},
+                                            "f:add": {}
+                                        }
+                                    },
+                                    "f:terminationMessagePath": {},
+                                    "f:terminationMessagePolicy": {}
+                                }
+                            },
+                            "f:dnsPolicy": {},
+                            "f:enableServiceLinks": {},
+                            "f:restartPolicy": {},
+                            "f:schedulerName": {},
+                            "f:securityContext": {},
+                            "f:terminationGracePeriodSeconds": {}
+                        }
+                    },
+                    "manager": "kubectl-client-side-apply",
+                    "operation": "Update",
+                    "time": "2023-04-12T12:42:27Z"
+                }
+            ],
+            "name": "hello",
+            "namespace": "default",
+            "uid": "d1dbc79a-8b52-4396-a882-a3fb8549a546"
+        },
+        "spec": {
+            "containers": [
+                {
+                    "command": [
+                        "sh",
+                        "-c",
+                        "echo 'Hello!' && sleep 1h"
+                    ],
+                    "image": "busybox",
+                    "imagePullPolicy": "Always",
+                    "name": "hello",
+                    "resources": {},
+                    "securityContext": {
+                        "capabilities": {
+                            "add": [
+                                "NET_ADMIN"
+                            ]
+                        }
+                    },
+                    "terminationMessagePath": "/dev/termination-log",
+                    "terminationMessagePolicy": "File",
+                    "volumeMounts": [
+                        {
+                            "mountPath": "/var/run/secrets/kubernetes.io/serviceaccount",
+                            "name": "kube-api-access-g4mxk",
+                            "readOnly": true
+                        }
+                    ]
+                }
+            ],
+            "dnsPolicy": "ClusterFirst",
+            "enableServiceLinks": true,
+            "preemptionPolicy": "PreemptLowerPriority",
+            "priority": 0,
+            "restartPolicy": "Always",
+            "schedulerName": "default-scheduler",
+            "securityContext": {},
+            "serviceAccount": "default",
+            "serviceAccountName": "default",
+            "terminationGracePeriodSeconds": 30,
+            "tolerations": [
+                {
+                    "effect": "NoExecute",
+                    "key": "node.kubernetes.io/not-ready",
+                    "operator": "Exists",
+                    "tolerationSeconds": 300
+                },
+                {
+                    "effect": "NoExecute",
+                    "key": "node.kubernetes.io/unreachable",
+                    "operator": "Exists",
+                    "tolerationSeconds": 300
+                }
+            ],
+            "volumes": [
+                {
+                    "name": "kube-api-access-g4mxk",
+                    "projected": {
+                        "defaultMode": 420,
+                        "sources": [
+                            {
+                                "serviceAccountToken": {
+                                    "expirationSeconds": 3607,
+                                    "path": "token"
+                                }
+                            },
+                            {
+                                "configMap": {
+                                    "items": [
+                                        {
+                                            "key": "ca.crt",
+                                            "path": "ca.crt"
+                                        }
+                                    ],
+                                    "name": "kube-root-ca.crt"
+                                }
+                            },
+                            {
+                                "downwardAPI": {
+                                    "items": [
+                                        {
+                                            "fieldRef": {
+                                                "apiVersion": "v1",
+                                                "fieldPath": "metadata.namespace"
+                                            },
+                                            "path": "namespace"
+                                        }
+                                    ]
+                                }
+                            }
+                        ]
+                    }
+                }
+            ]
+        },
+        "status": {
+            "phase": "Pending",
+            "qosClass": "BestEffort"
+        }
+    },
+    "operation": "CREATE",
+    "options": {
+        "apiVersion": "meta.k8s.io/v1",
+        "fieldManager": "kubectl-client-side-apply",
+        "fieldValidation": "Strict",
+        "kind": "CreateOptions"
+    },
+    "requestKind": {
+        "group": "",
+        "kind": "Pod",
+        "version": "v1"
+    },
+    "requestResource": {
+        "group": "",
+        "resource": "pods",
+        "version": "v1"
+    },
+    "resource": {
+        "group": "",
+        "resource": "pods",
+        "version": "v1"
+    },
+    "uid": "f0b8fba3-4f4f-465b-af8c-84d0326a2dc2",
+    "userInfo": {
+        "groups": [
+            "system:masters",
+            "system:authenticated"
+        ],
+        "username": "docker-for-desktop"
+    }
+}

--- a/test_data/req_pod_with_capabilities_in_required_drop_capabilities.json
+++ b/test_data/req_pod_with_capabilities_in_required_drop_capabilities.json
@@ -1,69 +1,12 @@
 {
-    "dryRun": false,
+    "uid": "f0b8fba3-4f4f-465b-af8c-84d0326a2dc2",
     "kind": {
-        "group": "",
         "kind": "Pod",
         "version": "v1"
     },
-    "name": "hello",
-    "namespace": "default",
     "object": {
-        "apiVersion": "v1",
-        "kind": "Pod",
         "metadata": {
-            "annotations": {
-                "io.kubewarden.policy.echo.create": "true",
-                "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Pod\",\"metadata\":{\"annotations\":{\"io.kubewarden.policy.echo.create\":\"true\"},\"name\":\"hello\",\"namespace\":\"default\"},\"spec\":{\"containers\":[{\"command\":[\"sh\",\"-c\",\"echo 'Hello!' \\u0026\\u0026 sleep 1h\"],\"image\":\"busybox\",\"name\":\"hello\",\"securityContext\":{\"capabilities\":{\"add\":[\"NET_ADMIN\"]}}}]}}\n"
-            },
-            "creationTimestamp": "2023-04-12T12:42:27Z",
-            "managedFields": [
-                {
-                    "apiVersion": "v1",
-                    "fieldsType": "FieldsV1",
-                    "fieldsV1": {
-                        "f:metadata": {
-                            "f:annotations": {
-                                ".": {},
-                                "f:io.kubewarden.policy.echo.create": {},
-                                "f:kubectl.kubernetes.io/last-applied-configuration": {}
-                            }
-                        },
-                        "f:spec": {
-                            "f:containers": {
-                                "k:{\"name\":\"hello\"}": {
-                                    ".": {},
-                                    "f:command": {},
-                                    "f:image": {},
-                                    "f:imagePullPolicy": {},
-                                    "f:name": {},
-                                    "f:resources": {},
-                                    "f:securityContext": {
-                                        ".": {},
-                                        "f:capabilities": {
-                                            ".": {},
-                                            "f:add": {}
-                                        }
-                                    },
-                                    "f:terminationMessagePath": {},
-                                    "f:terminationMessagePolicy": {}
-                                }
-                            },
-                            "f:dnsPolicy": {},
-                            "f:enableServiceLinks": {},
-                            "f:restartPolicy": {},
-                            "f:schedulerName": {},
-                            "f:securityContext": {},
-                            "f:terminationGracePeriodSeconds": {}
-                        }
-                    },
-                    "manager": "kubectl-client-side-apply",
-                    "operation": "Update",
-                    "time": "2023-04-12T12:42:27Z"
-                }
-            ],
-            "name": "hello",
-            "namespace": "default",
-            "uid": "d1dbc79a-8b52-4396-a882-a3fb8549a546"
+            "name": "hello"
         },
         "spec": {
             "containers": [
@@ -83,116 +26,22 @@
                                 "NET_ADMIN"
                             ]
                         }
-                    },
-                    "terminationMessagePath": "/dev/termination-log",
-                    "terminationMessagePolicy": "File",
-                    "volumeMounts": [
-                        {
-                            "mountPath": "/var/run/secrets/kubernetes.io/serviceaccount",
-                            "name": "kube-api-access-g4mxk",
-                            "readOnly": true
-                        }
-                    ]
-                }
-            ],
-            "dnsPolicy": "ClusterFirst",
-            "enableServiceLinks": true,
-            "preemptionPolicy": "PreemptLowerPriority",
-            "priority": 0,
-            "restartPolicy": "Always",
-            "schedulerName": "default-scheduler",
-            "securityContext": {},
-            "serviceAccount": "default",
-            "serviceAccountName": "default",
-            "terminationGracePeriodSeconds": 30,
-            "tolerations": [
-                {
-                    "effect": "NoExecute",
-                    "key": "node.kubernetes.io/not-ready",
-                    "operator": "Exists",
-                    "tolerationSeconds": 300
-                },
-                {
-                    "effect": "NoExecute",
-                    "key": "node.kubernetes.io/unreachable",
-                    "operator": "Exists",
-                    "tolerationSeconds": 300
-                }
-            ],
-            "volumes": [
-                {
-                    "name": "kube-api-access-g4mxk",
-                    "projected": {
-                        "defaultMode": 420,
-                        "sources": [
-                            {
-                                "serviceAccountToken": {
-                                    "expirationSeconds": 3607,
-                                    "path": "token"
-                                }
-                            },
-                            {
-                                "configMap": {
-                                    "items": [
-                                        {
-                                            "key": "ca.crt",
-                                            "path": "ca.crt"
-                                        }
-                                    ],
-                                    "name": "kube-root-ca.crt"
-                                }
-                            },
-                            {
-                                "downwardAPI": {
-                                    "items": [
-                                        {
-                                            "fieldRef": {
-                                                "apiVersion": "v1",
-                                                "fieldPath": "metadata.namespace"
-                                            },
-                                            "path": "namespace"
-                                        }
-                                    ]
-                                }
-                            }
-                        ]
                     }
+                    
                 }
-            ]
-        },
-        "status": {
-            "phase": "Pending",
-            "qosClass": "BestEffort"
+            ]  
         }
     },
     "operation": "CREATE",
-    "options": {
-        "apiVersion": "meta.k8s.io/v1",
-        "fieldManager": "kubectl-client-side-apply",
-        "fieldValidation": "Strict",
-        "kind": "CreateOptions"
-    },
     "requestKind": {
-        "group": "",
         "kind": "Pod",
         "version": "v1"
     },
-    "requestResource": {
-        "group": "",
-        "resource": "pods",
-        "version": "v1"
-    },
-    "resource": {
-        "group": "",
-        "resource": "pods",
-        "version": "v1"
-    },
-    "uid": "f0b8fba3-4f4f-465b-af8c-84d0326a2dc2",
     "userInfo": {
         "groups": [
             "system:masters",
             "system:authenticated"
         ],
-        "username": "docker-for-desktop"
+        "username": "shiva"
     }
-}
+  }

--- a/test_data/req_pod_with_mutate_capabilities.json
+++ b/test_data/req_pod_with_mutate_capabilities.json
@@ -1,198 +1,47 @@
 {
-  "dryRun": false,
-  "kind": {
-      "group": "",
-      "kind": "Pod",
-      "version": "v1"
-  },
-  "name": "hello",
-  "namespace": "default",
-  "object": {
-      "apiVersion": "v1",
-      "kind": "Pod",
-      "metadata": {
-          "annotations": {
-              "io.kubewarden.policy.echo.create": "true",
-              "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Pod\",\"metadata\":{\"annotations\":{\"io.kubewarden.policy.echo.create\":\"true\"},\"name\":\"hello\",\"namespace\":\"default\"},\"spec\":{\"containers\":[{\"command\":[\"sh\",\"-c\",\"echo 'Hello!' \\u0026\\u0026 sleep 1h\"],\"image\":\"busybox\",\"name\":\"hello\",\"securityContext\":{\"capabilities\":{\"add\":[\"NET_ADMIN\"]}}}]}}\n"
-          },
-          "creationTimestamp": "2023-04-12T12:42:27Z",
-          "managedFields": [
-              {
-                  "apiVersion": "v1",
-                  "fieldsType": "FieldsV1",
-                  "fieldsV1": {
-                      "f:metadata": {
-                          "f:annotations": {
-                              ".": {},
-                              "f:io.kubewarden.policy.echo.create": {},
-                              "f:kubectl.kubernetes.io/last-applied-configuration": {}
-                          }
-                      },
-                      "f:spec": {
-                          "f:containers": {
-                              "k:{\"name\":\"hello\"}": {
-                                  ".": {},
-                                  "f:command": {},
-                                  "f:image": {},
-                                  "f:imagePullPolicy": {},
-                                  "f:name": {},
-                                  "f:resources": {},
-                                  "f:securityContext": {
-                                      ".": {},
-                                      "f:capabilities": {
-                                          ".": {},
-                                          "f:add": {}
-                                      }
-                                  },
-                                  "f:terminationMessagePath": {},
-                                  "f:terminationMessagePolicy": {}
-                              }
-                          },
-                          "f:dnsPolicy": {},
-                          "f:enableServiceLinks": {},
-                          "f:restartPolicy": {},
-                          "f:schedulerName": {},
-                          "f:securityContext": {},
-                          "f:terminationGracePeriodSeconds": {}
-                      }
-                  },
-                  "manager": "kubectl-client-side-apply",
-                  "operation": "Update",
-                  "time": "2023-04-12T12:42:27Z"
-              }
-          ],
-          "name": "hello",
-          "namespace": "default",
-          "uid": "d1dbc79a-8b52-4396-a882-a3fb8549a546"
-      },
-      "spec": {
-          "containers": [
-              {
-                  "command": [
-                      "sh",
-                      "-c",
-                      "echo 'Hello!' && sleep 1h"
-                  ],
-                  "image": "busybox",
-                  "imagePullPolicy": "Always",
-                  "name": "hello",
-                  "resources": {},
-                  "securityContext": {
-                      "capabilities": {
-                          "add": [
-                              "KILL"
-                          ]
-                      }
-                  },
-                  "terminationMessagePath": "/dev/termination-log",
-                  "terminationMessagePolicy": "File",
-                  "volumeMounts": [
-                      {
-                          "mountPath": "/var/run/secrets/kubernetes.io/serviceaccount",
-                          "name": "kube-api-access-g4mxk",
-                          "readOnly": true
-                      }
-                  ]
-              }
-          ],
-          "dnsPolicy": "ClusterFirst",
-          "enableServiceLinks": true,
-          "preemptionPolicy": "PreemptLowerPriority",
-          "priority": 0,
-          "restartPolicy": "Always",
-          "schedulerName": "default-scheduler",
-          "securityContext": {},
-          "serviceAccount": "default",
-          "serviceAccountName": "default",
-          "terminationGracePeriodSeconds": 30,
-          "tolerations": [
-              {
-                  "effect": "NoExecute",
-                  "key": "node.kubernetes.io/not-ready",
-                  "operator": "Exists",
-                  "tolerationSeconds": 300
-              },
-              {
-                  "effect": "NoExecute",
-                  "key": "node.kubernetes.io/unreachable",
-                  "operator": "Exists",
-                  "tolerationSeconds": 300
-              }
-          ],
-          "volumes": [
-              {
-                  "name": "kube-api-access-g4mxk",
-                  "projected": {
-                      "defaultMode": 420,
-                      "sources": [
-                          {
-                              "serviceAccountToken": {
-                                  "expirationSeconds": 3607,
-                                  "path": "token"
-                              }
-                          },
-                          {
-                              "configMap": {
-                                  "items": [
-                                      {
-                                          "key": "ca.crt",
-                                          "path": "ca.crt"
-                                      }
-                                  ],
-                                  "name": "kube-root-ca.crt"
-                              }
-                          },
-                          {
-                              "downwardAPI": {
-                                  "items": [
-                                      {
-                                          "fieldRef": {
-                                              "apiVersion": "v1",
-                                              "fieldPath": "metadata.namespace"
-                                          },
-                                          "path": "namespace"
-                                      }
-                                  ]
-                              }
-                          }
-                      ]
-                  }
-              }
-          ]
-      },
-      "status": {
-          "phase": "Pending",
-          "qosClass": "BestEffort"
-      }
-  },
-  "operation": "CREATE",
-  "options": {
-      "apiVersion": "meta.k8s.io/v1",
-      "fieldManager": "kubectl-client-side-apply",
-      "fieldValidation": "Strict",
-      "kind": "CreateOptions"
-  },
-  "requestKind": {
-      "group": "",
-      "kind": "Pod",
-      "version": "v1"
-  },
-  "requestResource": {
-      "group": "",
-      "resource": "pods",
-      "version": "v1"
-  },
-  "resource": {
-      "group": "",
-      "resource": "pods",
-      "version": "v1"
-  },
-  "uid": "f0b8fba3-4f4f-465b-af8c-84d0326a2dc2",
-  "userInfo": {
-      "groups": [
-          "system:masters",
-          "system:authenticated"
-      ],
-      "username": "docker-for-desktop"
+    "uid": "f0b8fba3-4f4f-465b-af8c-84d0326a2dc2",
+    "kind": {
+        "kind": "Pod",
+        "version": "v1"
+    },
+    "object": {
+        "metadata": {
+            "name": "hello"
+        },
+        "spec": {
+            "containers": [
+                {
+                    "command": [
+                        "sh",
+                        "-c",
+                        "echo 'Hello!' && sleep 1h"
+                    ],
+                    "image": "busybox",
+                    "imagePullPolicy": "Always",
+                    "name": "hello",
+                    "resources": {},
+                    "securityContext": {
+                        "capabilities": {
+                            "add": [
+                                "KILL"
+                            ]
+                        }
+                    }
+                    
+                }
+            ]  
+        }
+    },
+    "operation": "CREATE",
+    "requestKind": {
+        "kind": "Pod",
+        "version": "v1"
+    },
+    "userInfo": {
+        "groups": [
+            "system:masters",
+            "system:authenticated"
+        ],
+        "username": "shiva"
+    }
   }
-}

--- a/test_data/req_pod_with_mutate_capabilities.json
+++ b/test_data/req_pod_with_mutate_capabilities.json
@@ -1,0 +1,198 @@
+{
+  "dryRun": false,
+  "kind": {
+      "group": "",
+      "kind": "Pod",
+      "version": "v1"
+  },
+  "name": "hello",
+  "namespace": "default",
+  "object": {
+      "apiVersion": "v1",
+      "kind": "Pod",
+      "metadata": {
+          "annotations": {
+              "io.kubewarden.policy.echo.create": "true",
+              "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Pod\",\"metadata\":{\"annotations\":{\"io.kubewarden.policy.echo.create\":\"true\"},\"name\":\"hello\",\"namespace\":\"default\"},\"spec\":{\"containers\":[{\"command\":[\"sh\",\"-c\",\"echo 'Hello!' \\u0026\\u0026 sleep 1h\"],\"image\":\"busybox\",\"name\":\"hello\",\"securityContext\":{\"capabilities\":{\"add\":[\"NET_ADMIN\"]}}}]}}\n"
+          },
+          "creationTimestamp": "2023-04-12T12:42:27Z",
+          "managedFields": [
+              {
+                  "apiVersion": "v1",
+                  "fieldsType": "FieldsV1",
+                  "fieldsV1": {
+                      "f:metadata": {
+                          "f:annotations": {
+                              ".": {},
+                              "f:io.kubewarden.policy.echo.create": {},
+                              "f:kubectl.kubernetes.io/last-applied-configuration": {}
+                          }
+                      },
+                      "f:spec": {
+                          "f:containers": {
+                              "k:{\"name\":\"hello\"}": {
+                                  ".": {},
+                                  "f:command": {},
+                                  "f:image": {},
+                                  "f:imagePullPolicy": {},
+                                  "f:name": {},
+                                  "f:resources": {},
+                                  "f:securityContext": {
+                                      ".": {},
+                                      "f:capabilities": {
+                                          ".": {},
+                                          "f:add": {}
+                                      }
+                                  },
+                                  "f:terminationMessagePath": {},
+                                  "f:terminationMessagePolicy": {}
+                              }
+                          },
+                          "f:dnsPolicy": {},
+                          "f:enableServiceLinks": {},
+                          "f:restartPolicy": {},
+                          "f:schedulerName": {},
+                          "f:securityContext": {},
+                          "f:terminationGracePeriodSeconds": {}
+                      }
+                  },
+                  "manager": "kubectl-client-side-apply",
+                  "operation": "Update",
+                  "time": "2023-04-12T12:42:27Z"
+              }
+          ],
+          "name": "hello",
+          "namespace": "default",
+          "uid": "d1dbc79a-8b52-4396-a882-a3fb8549a546"
+      },
+      "spec": {
+          "containers": [
+              {
+                  "command": [
+                      "sh",
+                      "-c",
+                      "echo 'Hello!' && sleep 1h"
+                  ],
+                  "image": "busybox",
+                  "imagePullPolicy": "Always",
+                  "name": "hello",
+                  "resources": {},
+                  "securityContext": {
+                      "capabilities": {
+                          "add": [
+                              "KILL"
+                          ]
+                      }
+                  },
+                  "terminationMessagePath": "/dev/termination-log",
+                  "terminationMessagePolicy": "File",
+                  "volumeMounts": [
+                      {
+                          "mountPath": "/var/run/secrets/kubernetes.io/serviceaccount",
+                          "name": "kube-api-access-g4mxk",
+                          "readOnly": true
+                      }
+                  ]
+              }
+          ],
+          "dnsPolicy": "ClusterFirst",
+          "enableServiceLinks": true,
+          "preemptionPolicy": "PreemptLowerPriority",
+          "priority": 0,
+          "restartPolicy": "Always",
+          "schedulerName": "default-scheduler",
+          "securityContext": {},
+          "serviceAccount": "default",
+          "serviceAccountName": "default",
+          "terminationGracePeriodSeconds": 30,
+          "tolerations": [
+              {
+                  "effect": "NoExecute",
+                  "key": "node.kubernetes.io/not-ready",
+                  "operator": "Exists",
+                  "tolerationSeconds": 300
+              },
+              {
+                  "effect": "NoExecute",
+                  "key": "node.kubernetes.io/unreachable",
+                  "operator": "Exists",
+                  "tolerationSeconds": 300
+              }
+          ],
+          "volumes": [
+              {
+                  "name": "kube-api-access-g4mxk",
+                  "projected": {
+                      "defaultMode": 420,
+                      "sources": [
+                          {
+                              "serviceAccountToken": {
+                                  "expirationSeconds": 3607,
+                                  "path": "token"
+                              }
+                          },
+                          {
+                              "configMap": {
+                                  "items": [
+                                      {
+                                          "key": "ca.crt",
+                                          "path": "ca.crt"
+                                      }
+                                  ],
+                                  "name": "kube-root-ca.crt"
+                              }
+                          },
+                          {
+                              "downwardAPI": {
+                                  "items": [
+                                      {
+                                          "fieldRef": {
+                                              "apiVersion": "v1",
+                                              "fieldPath": "metadata.namespace"
+                                          },
+                                          "path": "namespace"
+                                      }
+                                  ]
+                              }
+                          }
+                      ]
+                  }
+              }
+          ]
+      },
+      "status": {
+          "phase": "Pending",
+          "qosClass": "BestEffort"
+      }
+  },
+  "operation": "CREATE",
+  "options": {
+      "apiVersion": "meta.k8s.io/v1",
+      "fieldManager": "kubectl-client-side-apply",
+      "fieldValidation": "Strict",
+      "kind": "CreateOptions"
+  },
+  "requestKind": {
+      "group": "",
+      "kind": "Pod",
+      "version": "v1"
+  },
+  "requestResource": {
+      "group": "",
+      "resource": "pods",
+      "version": "v1"
+  },
+  "resource": {
+      "group": "",
+      "resource": "pods",
+      "version": "v1"
+  },
+  "uid": "f0b8fba3-4f4f-465b-af8c-84d0326a2dc2",
+  "userInfo": {
+      "groups": [
+          "system:masters",
+          "system:authenticated"
+      ],
+      "username": "docker-for-desktop"
+  }
+}


### PR DESCRIPTION
## Description
Added e2e tests to cover the Pod Security policy scenarios
These are the end-to-end scenarios covered:

 - Accept all capabilities when star(all) in allowed capabilities
 - Reject when star(all) in allowed capabilities and capabilities in required_drop_capabilities
 - Reject capabilities in required_drop_capabilities
 - Accept capabilities in allowed capabilities
 -  Reject capabilities not listed in allowed capabilities
 - Mutate pods

<!-- Please provide the link to the GitHub issue you are addressing -->
Fix https://github.com/kubewarden/capabilities-psp-policy/issues/8

<!-- Please provide the link to the documentation related to your change, if applicable -->
<!-- [Documentation](https://<insert your url>) -->

## Test

<!-- Please provides a short description about how to test your pullrequest -->
To test this pull request, you can run the following commands:
```shell
make e2e-tests
```
<!--
```shell
cp <to_package_directory>
go test
```
-->

## Additional Information

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->
Add more scenarios